### PR TITLE
chore: Use Ops.CollectStatus Event

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -98,6 +98,9 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
 @pytest.mark.abort_on_fail
 async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     await ops_test.model.remove_application(NRF_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    # Running config-changed hook with empty config to check whether _nrf_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APPLICATION_NAME].set_config({})  # type: ignore[union-attr]
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
 
 
@@ -122,6 +125,9 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
 async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(TLS_PROVIDER_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _tls_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APPLICATION_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
 
 
@@ -145,6 +151,9 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
 async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(DATABASE_APP_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _database_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APPLICATION_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=60)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -114,7 +114,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container=self.container_name, val=False)
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
         )
@@ -123,25 +123,32 @@ class TestCharm(unittest.TestCase):
         self,
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
-
+        self._create_nrf_relation()
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for `database` relation to be created"),
+            BlockedStatus("Waiting for database relation"),
         )
 
+    @patch("charm.generate_private_key")
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
-        self,
+        self, patch_generate_private_key
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation()
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        private_key = b"whatever key content"
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        patch_generate_private_key.return_value = private_key
 
+        self.harness.charm._on_certificates_relation_created(event=Mock)
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for `fiveg_nrf` relation to be created"),
+            BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
     def test_given_container_can_connect_and_certificates_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
@@ -152,10 +159,10 @@ class TestCharm(unittest.TestCase):
         self._create_nrf_relation()
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for `certificates` relation to be created"),
+            BlockedStatus("Waiting for certificates relation"),
         )
 
     @patch("charm.check_output")
@@ -181,7 +188,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(nrf_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg_nrf relation"),
@@ -210,7 +217,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(self.container_name)
 
         self.harness.remove_relation(database_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for database relation"),
@@ -227,7 +234,7 @@ class TestCharm(unittest.TestCase):
             relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
         )
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for `database` relation to be available"),
@@ -245,7 +252,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for NRF endpoint to be available"),
@@ -266,7 +273,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for the storage to be attached")
         )
@@ -290,7 +297,7 @@ class TestCharm(unittest.TestCase):
         patch_check_output.return_value = b"1.1.1.1"
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
@@ -448,7 +455,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
-
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     @patch("ops.model.Container.restart", new=Mock)
@@ -469,7 +476,7 @@ class TestCharm(unittest.TestCase):
             relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
         )
         self.harness.container_pebble_ready(container_name=self.container_name)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm.  Event named "collect_unit_status" sets the status of charm automatically at the end of every hook.

Reference:
- https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
- https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library