### PR TITLE
feat: Adding the Terraform module

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,6 +32,7 @@ assignees: ''
 - Juju version (output from `juju --version`):
 - Cloud Environment: <!-- e.g. GKE -->
 - Kubernetes version (output from `kubectl version --short`):
+- Terraform version (output from `terraform version`):
 
 #### Additional context
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,9 @@ jobs:
   lint-report:
     uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@main
 
+  terraform-check:
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@main
+
   static-analysis:
     uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@main
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,39 @@
 
 # Charmcraft
 *.charm
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+.terraform.lock.hcl

--- a/terraform/CONTRIBUTING.md
+++ b/terraform/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+## Development environment
+
+### Prerequisites
+
+Make sure the following software and tools are installed in the development
+environment.
+
+- `microk8s`
+- `juju`
+- `terraform`
+
+### Prepare Development Environment
+
+Install Microk8s:
+
+```console
+sudo snap install microk8s --channel=1.27-strict/stable
+sudo usermod -a -G snap_microk8s $USER
+newgrp snap_microk8s
+```
+
+Enable `storage` plugin for Microk8s:
+
+```console
+sudo microk8s enable hostpath-storage
+```
+
+Install Juju:
+
+```console
+sudo snap install juju --channel=3.1/stable
+```
+
+Install Terraform:
+
+```console
+sudo snap install --classic terraform
+```
+
+Bootstrap the Juju Controller using Microk8s:
+
+```console
+juju bootstrap microk8s
+```
+
+Add a Juju model:
+
+```console
+juju add model <model-name>
+````
+
+### Terraform provider
+
+The Terraform module uses the Juju provider to provision Juju resources. Please refer to the [Juju provider documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) for more information.
+
+A Terraform working directory needs to be initialized at the beginning.
+
+Initialise the provider:
+
+```console
+terraform init
+```
+
+## Testing
+
+Terraform CLI provides various ways to do formatting and validation.
+
+Formats to a canonical format and style:
+
+```console
+terraform fmt
+```
+
+Check the syntactical validation:
+
+```console
+terraform validate
+```
+
+Preview the changes:
+
+```console
+terraform plan
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,18 +39,18 @@ Replace the values in the `terraform.tfvars` file:
 ```yaml
 # Mandatory Config Options
 model_name             = "put your model-name here"
-db_application_name    = "put your mongodb app name here"
-certs_application_name = "put your self-signed-certificates app name here"
-nrf_application_name   = "put your nrf app name here"
+db_application_name    = "put your MongoDB app name here"
+certs_application_name = "put your Self Signed Certificates app name here"
+nrf_application_name   = "put your NRF app name here"
 ```
 
-Run Terraform Plan by providing var-file:
+Create the Terraform Plan:
 
 ```console
 terraform plan -var-file="terraform.tfvars" 
 ```
 
-Deploy the resources, skip the approval:
+Deploy the resources:
 
 ```console
 terraform apply -auto-approve 
@@ -66,7 +66,7 @@ juju status --relations
 
 ### Clean up
 
-Remove the applications:
+Destroy the deployment:
 
 ```console
 terraform destroy -auto-approve

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,73 @@
+# SD-Core PCF K8s Terraform Module
+
+This SD-Core PCF K8s Terraform module aims to deploy the [sdcore-pcf-k8s charm](https://charmhub.io/sdcore-pcf-k8s) via Terraform.
+
+## Getting Started
+
+### Prerequisites
+
+The following software and tools needs to be installed and should be running in the local environment.
+
+- `microk8s`
+- `juju 3.x`
+- `terrafom`
+
+### Deploy the sdcore-pcf-k8s charm using Terraform
+
+Make sure that `storage` plugin is enabled for Microk8s:
+
+```console
+sudo microk8s enable hostpath-storage
+```
+
+Add a Juju model:
+
+```console
+juju add model <model-name>
+```
+
+Initialise the provider:
+
+```console
+terraform init
+```
+
+Customize the configuration inputs under `terraform.tfvars` file according to requirement.
+
+Replace the values in the `terraform.tfvars` file:
+
+```yaml
+# Mandatory Config Options
+model_name             = "put your model-name here"
+db_application_name    = "put your mongodb app name here"
+certs_application_name = "put your self-signed-certificates app name here"
+nrf_application_name   = "put your nrf app name here"
+```
+
+Run Terraform Plan by providing var-file:
+
+```console
+terraform plan -var-file="terraform.tfvars" 
+```
+
+Deploy the resources, skip the approval:
+
+```console
+terraform apply -auto-approve 
+```
+
+### Check the Output
+
+Run `juju switch <juju model>` to switch to the target Juju model and observe the status of the applications.
+
+```console
+juju status --relations
+```
+
+### Clean up
+
+Remove the applications:
+
+```console
+terraform destroy -auto-approve
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,55 @@
+resource "juju_application" "pcf" {
+  name  = "pcf"
+  model = var.model_name
+
+  charm {
+    name    = "sdcore-pcf-k8s"
+    channel = var.channel
+  }
+
+  units = 1
+  trust = true
+}
+
+resource "juju_integration" "pcf-db" {
+  model = var.model_name
+
+  application {
+    name     = juju_application.pcf.name
+    endpoint = "database"
+  }
+
+  application {
+    name     = var.db_application_name
+    endpoint = "database"
+  }
+}
+
+resource "juju_integration" "pcf-certs" {
+  model = var.model_name
+
+  application {
+    name     = juju_application.pcf.name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = var.certs_application_name
+    endpoint = "certificates"
+  }
+}
+
+resource "juju_integration" "pcf-nrf" {
+  model = var.model_name
+
+  application {
+    name     = juju_application.pcf.name
+    endpoint = "fiveg_nrf"
+  }
+
+  application {
+    name     = var.nrf_application_name
+    endpoint = "fiveg-nrf"
+  }
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "pcf_application_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.pcf.name
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.10.1"
+    }
+  }
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 terraform {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,8 @@
+# Mandatory Config Options
+model_name             = "put your model-name here"
+db_application_name    = "put your mongodb app name here"
+certs_application_name = "put your self-signed-certificates app name here"
+nrf_application_name   = "put your nrf app name here"
+
+# Optional Configuration
+channel = "put the charm channel here"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,8 +1,8 @@
 # Mandatory Config Options
 model_name             = "put your model-name here"
-db_application_name    = "put your mongodb app name here"
-certs_application_name = "put your self-signed-certificates app name here"
-nrf_application_name   = "put your nrf app name here"
+db_application_name    = "put your MongoDB app name here"
+certs_application_name = "put your Self Signed Certificates app name here"
+nrf_application_name   = "put your NRF app name here"
 
 # Optional Configuration
 channel = "put the charm channel here"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "model_name" {
+  description = "Name of Juju model to deploy application to."
+  type        = string
+  default     = ""
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "1.3/edge"
+}
+
+variable "db_application_name" {
+  description = "The name of the application providing the `database` endpoint."
+  type        = string
+  default     = ""
+}
+
+variable "certs_application_name" {
+  description = "Name of the application providing the `certificates` integration endpoint."
+  type        = string
+  default     = ""
+}
+
+variable "nrf_application_name" {
+  description = "The name of the application providing the `fiveg_nrf` endpoint."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Description

This PR adds the Terraform module for the charm. Hence, the charm could be deployed using Terraform.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library