### PR TITLE
chore: use pytest for UT

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -502,12 +502,10 @@ class PCFOperatorCharm(CharmBase):
         return bool(self._nrf_requires.nrf_url)
 
     def _storage_is_attached(self) -> bool:
-        """Return whether storage is attached to the workload container.
-
-        Returns:
-            bool: Whether storage is attached.
-        """
-        return self._container.exists(path=BASE_CONFIG_PATH)
+        """Return whether storage is attached to the workload container."""
+        return self._container.exists(path=BASE_CONFIG_PATH) and self._container.exists(
+            path=CERTS_DIR_PATH
+        )
 
     @property
     def _pebble_layer(self) -> Layer:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,9 +2,9 @@
 # See LICENSE file for licensing details.
 
 import logging
-import unittest
 from unittest.mock import Mock, PropertyMock, patch
 
+import pytest
 import yaml
 from charm import (
     CONFIG_FILE_NAME,
@@ -21,121 +21,134 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
-POD_IP = b"1.1.1.1"
-VALID_NRF_URL = "https://nrf:443"
-EXPECTED_CONFIG_FILE_PATH = "tests/unit/expected_pcfcfg.yaml"
+CERTIFICATE = "whatever certificate content"
 CERTIFICATES_LIB = (
     "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3"
 )
-CERTIFICATE = "whatever certificate content"
+CERTIFICATE_PATH = "support/TLS/pcf.pem"
 CSR = "whatever CSR content"
+CSR_PATH = "support/TLS/pcf.csr"
+DATABASE_APP_NAME = "mongodb-k8s"
+EXPECTED_CONFIG_FILE_PATH = "tests/unit/expected_pcfcfg.yaml"
+POD_IP = b"1.1.1.1"
+PRIVATE_KEY = "whatever key content"
+PRIVATE_KEY_PATH = "support/TLS/pcf.key"
+VALID_NRF_URL = "https://nrf:443"
 
 
-class TestCharm(unittest.TestCase):
+class TestCharm:
+
+    patcher_check_output = patch("charm.check_output")
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_certificates = patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
+    patcher_nrf_url = patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)  # noqa: E501
+    patcher_request_certificate = patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
+    patcher_restart_container = patch("ops.model.Container.restart")
+
+    @pytest.fixture()
     def setUp(self):
-        self.maxDiff = None
-        self.namespace = "whatever"
-        self.default_database_application_name = "mongodb-k8s"
-        self.metadata = self._get_metadata()
-        self.container_name = list(self.metadata["containers"].keys())[0]
+        metadata = self._get_metadata()
+        self.container_name = list(metadata["containers"].keys())[0]
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
+        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
+        self.mock_get_certificates = TestCharm.patcher_get_certificates.start()
+        self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
+        self.mock_request_certificate = TestCharm.patcher_request_certificate.start()
+        self.mock_restart_container = TestCharm.patcher_restart_container.start()
+
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+
+    @pytest.fixture()
+    def mock_default_values(self) -> None:
+        self.mock_nrf_url.return_value = VALID_NRF_URL
+        self.mock_check_output.return_value = POD_IP
+        self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request, mock_default_values):
         self.harness = testing.Harness(PCFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name="whatever")
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
+
+    @pytest.fixture()
+    def add_storage(self) -> None:
+        self.harness.add_storage(storage_name="certs", attach=True)  # type:ignore
+        self.harness.add_storage(storage_name="config", attach=True)  # type:ignore
+
+    @pytest.fixture()
+    def get_default_certificate(self) -> None:
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR
+        self.mock_get_certificates.return_value = [provider_certificate]
 
     @staticmethod
     def _get_metadata() -> dict:
-        """Read `charmcraft.yaml` and returns it as a dictionary.
-
-        Returns:
-            dics: charmcraft.yaml as a dictionary.
-        """
+        """Read `charmcraft.yaml` and return its content as a dictionary."""
         with open("charmcraft.yaml", "r") as f:
             data = yaml.safe_load(f)
         return data
 
     @staticmethod
     def _read_file(path: str) -> str:
-        """Read a file and returns as a string.
-
-        Args:
-            path (str): path to the file.
-
-        Returns:
-            str: content of the file.
-        """
+        """Read a file and return its content as a string."""
         with open(path, "r") as f:
             content = f.read()
         return content
 
     def _create_database_relation(self) -> int:
-        """Create database relation.
-
-        Returns:
-            int: relation id.
-        """
-        database_app_name = "mongodb-k8s"
-        relation_id = self.harness.add_relation(
-            relation_name=DATABASE_RELATION_NAME, remote_app=database_app_name
+        relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=DATABASE_RELATION_NAME, remote_app=DATABASE_APP_NAME
         )
-        self.harness.add_relation_unit(
-            relation_id=relation_id, remote_unit_name=f"{database_app_name}/0"
+        self.harness.add_relation_unit(  # type:ignore
+            relation_id=relation_id, remote_unit_name=f"{DATABASE_APP_NAME}/0"
         )
         return relation_id
 
     def _create_database_relation_and_populate_data(self) -> int:
-        database_url = "http://1.1.1.1"
-        database_username = "banana"
-        database_password = "pizza"
         database_relation_id = self._create_database_relation()
-        self.harness.update_relation_data(
+        self.harness.update_relation_data(  # type:ignore
             relation_id=database_relation_id,
-            app_or_unit=self.default_database_application_name,
+            app_or_unit=DATABASE_APP_NAME,
             key_values={
-                "username": database_username,
-                "password": database_password,
-                "uris": "".join([database_url]),
+                "username": "banana",
+                "password": "pizza",
+                "uris": "http://1.1.1.1",
             },
         )
         return database_relation_id
 
     def _create_nrf_relation(self) -> int:
-        """Create NRF relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
+        relation_id = self.harness.add_relation(  # type:ignore
             relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
         )
-        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")  # type:ignore
         return relation_id
 
-    def _create_certificates_relation(self) -> int:
-        """Create certificates relation.
-
-        Returns:
-            int: relation id.
-        """
-        relation_id = self.harness.add_relation(
+    def _create_certificates_relation(self):
+        relation_id = self.harness.add_relation(  # type:ignore
             relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
         )
-        self.harness.add_relation_unit(
+        self.harness.add_relation_unit(  # type:ignore
             relation_id=relation_id, remote_unit_name="tls-certificates-operator/0"
         )
-        return relation_id
 
-    def test_given_container_cant_connect_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self,
-    ):
+    def test_given_container_cant_connect_when_configure_sdcore_pcf_then_status_is_waiting(self):
         self.harness.set_can_connect(container=self.container_name, val=False)
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for container to be ready")
-        )
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_container_can_connect_and_database_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
         self,
@@ -144,10 +157,8 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
         self,
@@ -157,10 +168,8 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
     def test_given_container_can_connect_and_certificates_relation_is_not_created_when_configure_sdcore_pcf_then_status_is_blocked(  # noqa: E501
         self,
@@ -171,257 +180,161 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for certificates relation"),
-        )
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
+
     def test_given_pcf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
-        self, _, patched_nrf_url, patch_check_output
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="config", attach=True)
-        self.harness.add_storage(storage_name="certs", attach=True)
-        root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        patch_check_output.return_value = POD_IP
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         nrf_relation_id = self._create_nrf_relation()
         self._create_database_relation_and_populate_data()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+
         self.harness.remove_relation(nrf_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+
     def test_given_pcf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
-        self, _, patched_nrf_url, patch_check_output
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="config", attach=True)
-        self.harness.add_storage(storage_name="certs", attach=True)
-        root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        patch_check_output.return_value = POD_IP
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         self._create_nrf_relation()
         database_relation_id = self._create_database_relation_and_populate_data()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
         self.harness.container_pebble_ready(self.container_name)
+
         self.harness.remove_relation(database_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
     def test_given_container_can_connect_and_database_relation_is_not_available_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self,
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation()
         self._create_nrf_relation()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
+
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for `database` relation to be available"),
-        )
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for `database` relation to be available")  # noqa: E501
 
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_available_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self,
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
+        self.mock_nrf_url.return_value = None
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for NRF endpoint to be available"),
-        )
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF endpoint to be available")  # noqa: E501
+
+    @pytest.mark.parametrize(
+        "storage_name",
+        [
+            "certs",
+            "config",
+        ]
+    )
     def test_given_container_storage_is_not_attached_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self,
-        patched_nrf_url,
+        self, storage_name
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
-
-        self.harness.charm._configure_sdcore_pcf(event=Mock())
-        self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for the storage to be attached")
-        )
-
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    def test_given_certificate_is_not_stored_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
-        self,
-        patched_nrf_url,
-        patch_check_output,
-    ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
-        self._create_database_relation_and_populate_data()
-        self._create_nrf_relation()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
-        patch_check_output.return_value = b"1.1.1.1"
-
-        self.harness.charm._configure_sdcore_pcf(event=Mock())
-        self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
-        )
-
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    def test_given_config_file_is_not_written_when_configure_sdcore_pcf_is_called_then_config_file_is_written_with_expected_content(  # noqa: E501
-        self, patched_nrf_url, patch_check_output, patch_get_assigned_certificates
-    ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        patch_check_output.return_value = POD_IP
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
+        self.harness.add_storage(storage_name=storage_name, attach=True)
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
         self._create_certificates_relation()
 
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.harness.charm._configure_sdcore_pcf(event=Mock())
+        self.harness.evaluate_status()
 
-        expected_config_file_content = self._read_file(EXPECTED_CONFIG_FILE_PATH)
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for the storage to be attached")  # noqa: E501
+
+    def test_given_certificate_is_not_stored_when_configure_sdcore_pcf_then_status_is_waiting(  # noqa: E501
+        self, add_storage
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self._create_database_relation_and_populate_data()
+        self._create_nrf_relation()
+        self._create_certificates_relation()
+
+        self.harness.charm._configure_sdcore_pcf(event=Mock())
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
+
+    def test_given_config_file_is_not_written_when_configure_sdcore_pcf_is_called_then_config_file_is_written_with_expected_content(  # noqa: E501
+        self, add_storage, get_default_certificate
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        self._create_database_relation_and_populate_data()
+        self._create_nrf_relation()
+        self._create_certificates_relation()
 
         self.harness.charm._configure_sdcore_pcf(event=Mock())
 
-        self.assertEqual(
-            (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text(),
-            expected_config_file_content.strip(),
-        )
+        expected_config_file_content = self._read_file(EXPECTED_CONFIG_FILE_PATH).strip()
+        assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text() == expected_config_file_content
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_config_file_is_written_and_is_not_changed_when_configure_sdcore_pcf_is_called_then_config_file_is_not_written(  # noqa: E501
-        self, patched_nrf_url, patch_check_output
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / f"etc/pcf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_pcfcfg.yaml").strip()
+            self._read_file(EXPECTED_CONFIG_FILE_PATH).strip()
         )
         config_modification_time = (root / f"etc/pcf/{CONFIG_FILE_NAME}").stat().st_mtime
-        patch_check_output.return_value = POD_IP
-        patched_nrf_url.return_value = VALID_NRF_URL
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
         self.harness.charm._certificate_is_stored = Mock(return_value=True)
 
         self.harness.container_pebble_ready(self.container_name)
 
-        self.assertEqual(
-            (root / f"etc/pcf/{CONFIG_FILE_NAME}").stat().st_mtime, config_modification_time
-        )
+        assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").stat().st_mtime == config_modification_time
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_config_file_exists_and_is_changed_when_configure_pcf_then_config_file_is_updated(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_nrf_url,
-        patch_get_assigned_certificates,
+        self, add_storage, get_default_certificate
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / f"etc/pcf/{CONFIG_FILE_NAME}").write_text("super different config file content")
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
         self._create_certificates_relation()
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-        self.harness.set_can_connect(container=self.container_name, val=True)
+
         self.harness.container_pebble_ready(self.container_name)
 
-        expected_content = self._read_file("tests/unit/expected_pcfcfg.yaml")
-        self.assertEqual(
-            (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text(), expected_content.strip()
-        )
+        expected_content = self._read_file(EXPECTED_CONFIG_FILE_PATH)
+        assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text() == expected_content.strip()
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("charm.check_output")
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_pcf_is_called_then_expected_plan_is_applied(  # noqa: E501
-        self, patch_check_output, patch_nrf_url, patch_get_assigned_certificates
+        self, add_storage, get_default_certificate
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        patch_check_output.return_value = POD_IP
-        patch_nrf_url.return_value = VALID_NRF_URL
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
         self._create_certificates_relation()
-
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-
-        self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.container_pebble_ready(self.container_name)
 
@@ -443,268 +356,167 @@ class TestCharm(unittest.TestCase):
             },
         }
         updated_plan = self.harness.get_container_pebble_plan(self.container_name).to_dict()
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("ops.model.Container.restart")
     def test_given_config_file_is_written_when_configure_sdcore_pcf_is_called_then_status_is_active(  # noqa: E501
-        self, _, patched_nrf_url, patch_check_output, patch_get_assigned_certificates
+        self, add_storage, get_default_certificate
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        (root / f"etc/pcf/{CONFIG_FILE_NAME}").write_text("super different config file content")
-        pod_ip = "1.1.1.1"
-        patch_check_output.return_value = pod_ip.encode()
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
         self._create_nrf_relation()
         self._create_database_relation_and_populate_data()
         self._create_certificates_relation()
+
         self.harness.container_pebble_ready(container_name=self.container_name)
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
-    @patch("ops.model.Container.restart", new=Mock)
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    def test_given_ip_not_available_when_configure_then_status_is_waiting(
-        self, _, patch_check_output
-    ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
+        assert self.harness.model.unit.status == ActiveStatus()
+
+    def test_given_ip_not_available_when_configure_then_status_is_waiting(self, add_storage):
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
-        patch_check_output.return_value = "".encode()
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        self.mock_check_output.return_value = "".encode()
         self._create_nrf_relation()
         self._create_database_relation_and_populate_data()
-        self.harness.add_relation(
-            relation_name=TLS_RELATION_NAME, remote_app="tls-certificates-operator"
-        )
+        self._create_certificates_relation()
+
         self.harness.container_pebble_ready(container_name=self.container_name)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for pod IP address to be available"),
-        )
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
+
     def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
-        self,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_nrf_url,
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = b"whatever key content"
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_generate_private_key.return_value = private_key
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_nrf_url.return_value = VALID_NRF_URL
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
         self._create_certificates_relation()
 
-        self.assertEqual((root / "support/TLS/pcf.key").read_text(), private_key.decode())
+        assert (root / PRIVATE_KEY_PATH).read_text() == PRIVATE_KEY
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
-        self,
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
 
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/pcf.pem").read_text()
-            (root / "support/TLS/pcf.key").read_text()
-            (root / "support/TLS/pcf.csr").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / CERTIFICATE_PATH).read_text()
+            (root / PRIVATE_KEY_PATH).read_text()
+            (root / CSR_PATH).read_text()
 
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, patch_check_output, patch_generate_csr, patched_nrf_url
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
-        patch_check_output.return_value = b"1.1.1.1"
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        self.mock_generate_csr.return_value = CSR.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
+
         self._create_certificates_relation()
 
-        self.assertEqual((root / "support/TLS/pcf.csr").read_text(), csr.decode())
+        assert (root / CSR_PATH).read_text() == CSR
 
-    @patch(
-        f"{CERTIFICATES_LIB}.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
     def test_given_private_key_exists_and_cert_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
-        self,
-        patch_check_output,
-        patch_generate_csr,
-        patched_nrf_url,
-        patch_request_certificate_creation,
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
-        patch_check_output.return_value = b"1.1.1.1"
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        self.mock_generate_csr.return_value = CSR.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
-
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
+
         self._create_certificates_relation()
 
-        patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+        self.mock_request_certificate.assert_called_with(certificate_signing_request=CSR.encode())
 
-    @patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_cert_already_stored_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
-        self, patch_check_output, patched_nrf_url, patch_request_certificate_creation
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
-        root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_check_output.return_value = b"1.1.1.1"
-        patched_nrf_url.return_value = VALID_NRF_URL
-
-        patch_request_certificate_creation.assert_not_called()
-
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
-    def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
-    ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        patch_check_output.return_value = b"1.1.1.1"
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / CSR_PATH).write_text(CSR)
+        self._create_database_relation_and_populate_data()
+        self._create_nrf_relation()
+
+        self._create_certificates_relation()
+
+        self.mock_request_certificate.assert_not_called()
+
+    def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
+        self, add_storage, get_default_certificate
+    ):
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
         self._create_database_relation_and_populate_data()
         self._create_nrf_relation()
         self._create_certificates_relation()
 
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        patch_get_assigned_certificates.return_value = [provider_certificate]
-        self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.container_pebble_ready(self.container_name)
 
-        self.assertEqual((root / "support/TLS/pcf.pem").read_text(), CERTIFICATE)
+        assert (root / CERTIFICATE_PATH).read_text() == CERTIFICATE
 
-    @patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charm.check_output")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
-        self, patch_check_output, patched_nrf_url, patch_get_assigned_certificates
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
-        self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        (root / "support/TLS/pcf.csr").write_text(CSR)
-        patch_check_output.return_value = b"1.1.1.1"
-        patched_nrf_url.return_value = VALID_NRF_URL
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CSR_PATH).write_text(CSR)
         self._create_nrf_relation()
         self._create_certificates_relation()
-        self.harness.set_can_connect(container=self.container_name, val=True)
-
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = CERTIFICATE
         provider_certificate.csr = "Relation CSR content (different from stored one)"
-        patch_get_assigned_certificates.return_value = [provider_certificate]
+        self.mock_get_certificates.return_value = [provider_certificate]
 
         self.harness.container_pebble_ready(self.container_name)
 
-        with self.assertRaises(FileNotFoundError):
-            (root / "support/TLS/pcf.pem").read_text()
+        with pytest.raises(FileNotFoundError):
+            (root / CERTIFICATE_PATH).read_text()
 
-    @patch(
-        f"{CERTIFICATES_LIB}.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         event = Mock()
         event.certificate = "Relation certificate content (different from stored)"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate.assert_not_called()
 
-    @patch(
-        f"{CERTIFICATES_LIB}.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_matches_stored_one_when_certificate_expiring_then_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self, add_storage
     ):
-        self.harness.add_storage(storage_name="certs", attach=True)
         root = self.harness.get_filesystem_root(self.container_name)
-        private_key = "whatever key content"
-        (root / "support/TLS/pcf.key").write_text(private_key)
-        (root / "support/TLS/pcf.pem").write_text(CERTIFICATE)
+        (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         event = Mock()
         event.certificate = CERTIFICATE
-        patch_generate_csr.return_value = CSR.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_called_with(
+        self.mock_request_certificate.assert_called_with(
             certificate_signing_request=CSR.encode()
         )


### PR DESCRIPTION
# Description

Remove `unittest` and use only `pytest` framework to run the unit tests.
https://juju.is/docs/sdk/write-a-unit-test-for-a-charm

Actions on this PR:

- Add a `@pytest.fixture` configure harness
- Add a `@pytest.fixture` setup patches, mock default values, add storage and setup harness.
- Continue using `Mock` and `patch` from the `unittest.Mock` library
- Use `assert` instead of `self.assert...` methods
- Add a parameterized test using `@pytest.mark.parametrize`

- Add `certs` storage verification on the charm code.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library