### PR TITLE
feat: Implement the requirer side of sdcore_config interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ juju integrate sdcore-nrf-k8s self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-pcf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-pcf-k8s:certificates self-signed-certificates:certificates
-juju integrate sdcore-nssf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
+juju integrate sdcore-pcf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```
 
 ## Image

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ A Charmed Operator for SD-Core's Policy Control Function (PCF) component for K8s
 juju deploy mongodb-k8s --channel=6/beta --trust
 juju deploy sdcore-nrf-k8s --channel=1.5/edge
 juju deploy sdcore-pcf-k8s --channel=1.5/edge 
-
+juju deploy sdcore-webui-k8s --channel=1.5/edge
 juju deploy self-signed-certificates --channel=stable
 
+juju integrate sdcore-webui-k8s:common_database mongodb-k8s:database
+juju integrate sdcore-webui-k8s:auth_database mongodb-k8s:database
 juju integrate sdcore-nrf-k8s self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-pcf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-pcf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-nssf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```
 
 ## Image

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,6 +41,8 @@ requires:
     interface: tls-certificates
   logging:
       interface: loki_push_api
+  sdcore_config:
+    interface: sdcore_config
 
 assumes:
   - k8s-api

--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
@@ -1,0 +1,339 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Library for the `sdcore_config` relation.
+
+This library contains the Requires and Provides classes for handling the `sdcore_config`
+interface.
+
+The purpose of this library is to relate charms claiming
+to be able to provide or consume the information to access the webui GRPC address
+for configuration purposes in SD-Core.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.sdcore_webui_k8s.v0.sdcore_config
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+### Requirer charm
+The requirer charm is the one requiring the Webui information.
+
+Example:
+```python
+
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import (
+    SdcoreConfigRequires,
+    WebuiBroken,
+    WebuiUrlAvailable,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DummySdcoreConfigRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_requirer = SdcoreConfigRequires(
+            self, "sdcore_config"
+        )
+        self.framework.observe(
+            self.webui_requirer.on.webui_url_available,
+            self._on_webui_url_available
+        )
+        self.framework.observe(self.webui_requirer.on.webui_broken, self._on_webui_broken)
+
+    def _on_webui_url_available(self, event: WebuiUrlAvailable):
+        logging.info(f"Webui URL from the event: {event.webui_url}")
+        logging.info(f"Webui URL from the property: {self.webui_requirer.webui_url}")
+
+    def _on_webui_broken(self, event: WebuiBroken) -> None:
+        logging.info(f"Received {event}")
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigRequirerCharm)
+```
+
+### Provider charm
+The provider charm is the one providing the information about the Webui.
+
+Example:
+```python
+
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import SdcoreConfigProvides
+
+
+class DummySdcoreConfigProviderCharm(CharmBase):
+
+    WEBUI_URL = "sdcore-webui-k8s:9876"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_url_provider = SdcoreConfigProvides(self, "sdcore_config")
+        self.framework.observe(
+            self.on.sdcore_config_relation_joined, self._on_sdcore_config_relation_joined
+        )
+
+    def _on_sdcore_config_relation_joined(self, event: RelationJoinedEvent):
+        relation_id = event.relation.id
+        self.webui_url_provider.set_webui_url(
+            webui_url=self.WEBUI_URL,
+            relation_id=relation_id,
+        )
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigProviderCharm)
+```
+
+"""
+import logging
+from typing import Optional
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.model import Relation
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e2f454cc121f449bbaa8fb0fd5a9867b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `sdcore_config` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "webui_url": "sdcore-webui-k8s:9876",
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class SdcoreConfigProviderAppData(BaseModel):
+    """Provider application data for sdcore_config."""
+    webui_url: str = Field(
+        description="GRPC address of the Webui including Webui hostname and a fixed GRPC port.",
+        examples=["sdcore-webui-k8s:9876"]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the sdcore-config interface."""
+    app: SdcoreConfigProviderAppData
+
+
+def data_is_valid(data: dict) -> bool:
+    """Return whether data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class WebuiUrlAvailable(EventBase):
+    """Charm event emitted when the Webui URL is available."""
+
+    def __init__(self, handle: Handle, webui_url: str):
+        """Init."""
+        super().__init__(handle)
+        self.webui_url = webui_url
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "webui_url": self.webui_url,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restore snapshot."""
+        self.webui_url = snapshot["webui_url"]
+
+
+class WebuiBroken(EventBase):
+    """Charm event emitted when the Webui goes down."""
+
+    def __init__(self, handle: Handle):
+        """Init."""
+        super().__init__(handle)
+
+
+class SdcoreConfigRequirerCharmEvents(CharmEvents):
+    """List of events that the SD-Core config requirer charm can leverage."""
+
+    webui_url_available = EventSource(WebuiUrlAvailable)
+    webui_broken = EventSource(WebuiBroken)
+
+
+class SdcoreConfigRequires(Object):
+    """Class to be instantiated by the SD-Core config requirer charm."""
+
+    on = SdcoreConfigRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle relation changed event.
+
+        Args:
+            event (RelationChangedEvent): Juju event.
+
+        Returns:
+            None
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
+            self.on.webui_url_available.emit(
+                webui_url=remote_app_relation_data,
+            )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle the Sdcore config relation broken event.
+
+        Args:
+            event (RelationBrokenEvent): Juju event.
+        """
+        self.on.webui_broken.emit()
+
+    @property
+    def webui_url(self) -> Optional[str]:
+        """Return the address of the webui GRPC endpoint.
+
+        Returns:
+            str: Endpoint address.
+        """
+        return self._get_remote_app_relation_data()
+
+    def _get_remote_app_relation_data(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Get relation data for the remote application.
+
+        Args:
+            relation: Juju relation object (optional).
+
+        Returns:
+        str: Relation data for the remote application
+            or None if the relation data is invalid.
+        """
+        relation = relation or self.model.get_relation(self.relation_name)
+
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+
+        remote_app_relation_data = dict(relation.data[relation.app])
+
+        if not data_is_valid(remote_app_relation_data):
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+
+        return remote_app_relation_data["webui_url"]
+
+
+class SdcoreConfigProvides(Object):
+    """Class to be instantiated by the charm providing the SD-Core Webui URL."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+    def set_webui_url(self, webui_url: str, relation_id: int) -> None:
+        """Set the address of the Webui GRPC endpoint.
+
+        Args:
+            webui_url (str): Webui GRPC service address.
+            relation_id (int): Relation ID.
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        if relation not in self.model.relations[self.relation_name]:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        relation.data[self.charm.app].update({"webui_url": webui_url})
+
+    def set_webui_url_in_all_relations(self, webui_url: str) -> None:
+        """Set Webui URL in applications for all applications.
+
+        Args:
+            webui_url (str): Webui GRPC service address
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relations = self.model.relations[self.relation_name]
+
+        if not relations:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        for relation in relations:
+            relation.data[self.charm.app].update({"webui_url": webui_url})

--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,7 @@ class PCFOperatorCharm(CharmBase):
             charm=self, relation_name=SDCORE_CONFIG_RELATION_NAME
         )
         self.unit.set_ports(PCF_SBI_PORT)
-        self._certificates = TLSCertificatesRequiresV3(self, "certificates")
+        self._certificates = TLSCertificatesRequiresV3(self, TLS_RELATION_NAME)
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self.framework.observe(self.on.update_status, self._configure_sdcore_pcf)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,10 +7,13 @@
 import logging
 from ipaddress import IPv4Address
 from subprocess import check_output
-from typing import Optional
+from typing import List, Optional
 
 from charms.loki_k8s.v1.loki_push_api import LogForwarder  # type: ignore[import]
 from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_webui_k8s.v0.sdcore_config import (  # type: ignore[import]
+    SdcoreConfigRequires,
+)
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
     CertificateExpiringEvent,
     TLSCertificatesRequiresV3,
@@ -44,6 +47,7 @@ CSR_NAME = "pcf.csr"
 CERTIFICATE_NAME = "pcf.pem"
 CERTIFICATE_COMMON_NAME = "pcf.sdcore"
 LOGGING_RELATION_NAME = "logging"
+SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
 
 
 class PCFOperatorCharm(CharmBase):
@@ -57,6 +61,9 @@ class PCFOperatorCharm(CharmBase):
         self._container = self.unit.get_container(self._container_name)
 
         self._nrf_requires = NRFRequires(charm=self, relation_name=NRF_RELATION_NAME)
+        self._webui_requires = SdcoreConfigRequires(
+            charm=self, relation_name=SDCORE_CONFIG_RELATION_NAME
+        )
         self.unit.set_ports(PCF_SBI_PORT)
         self._certificates = TLSCertificatesRequiresV3(self, "certificates")
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
@@ -75,6 +82,48 @@ class PCFOperatorCharm(CharmBase):
         self.framework.observe(
             self._certificates.on.certificate_expiring, self._on_certificate_expiring
         )
+        self.framework.observe(
+            self._webui_requires.on.webui_url_available,
+            self._configure_sdcore_pcf
+        )
+        self.framework.observe(self.on.sdcore_config_relation_joined, self._configure_sdcore_pcf)
+
+    def _configure_sdcore_pcf(self, event: EventBase) -> None:
+        """Handle Juju events.
+
+        This event handler is called for every event that affects the charm state
+        (ex. configuration files, relation data). This method performs a couple of checks
+        to make sure that the workload is ready to be started. Then, it configures the PCF
+        workload and runs the Pebble services.
+
+        Args:
+            event (EventBase): Juju event
+        """
+        if not self.ready_to_configure():
+            logger.info("The preconditions for the configuration are not met yet.")
+            return
+
+        if not self._private_key_is_stored():
+            self._generate_private_key()
+
+        if not self._csr_is_stored():
+            self._request_new_certificate()
+
+        provider_certificate = self._get_current_provider_certificate()
+        if not provider_certificate:
+            return
+
+        if certificate_update_required := self._is_certificate_update_required(
+            provider_certificate
+        ):
+            self._store_certificate(certificate=provider_certificate)
+
+        desired_config_file = self._generate_pcf_config_file()
+        if config_update_required := self._is_config_update_required(desired_config_file):
+            self._push_config_file(content=desired_config_file)
+
+        should_restart = config_update_required or certificate_update_required
+        self._configure_pebble(restart=should_restart)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired."""
@@ -91,13 +140,20 @@ class PCFOperatorCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for container to be ready"))
             return
 
-        for relation in [NRF_RELATION_NAME, TLS_RELATION_NAME]:
-            if not self._relation_created(relation):
-                event.add_status(BlockedStatus(f"Waiting for {relation} relation"))
-                return
+        if missing_relations := self._missing_relations():
+            event.add_status(
+                BlockedStatus(f"Waiting for {', '.join(missing_relations)} relation(s)")
+            )
+            logger.info("Waiting for %s  relation(s)", ', '.join(missing_relations))
+            return
 
         if not self._nrf_is_available():
             event.add_status(WaitingStatus("Waiting for NRF endpoint to be available"))
+            return
+
+        if not self._webui_url_is_available:
+            event.add_status(WaitingStatus("Waiting for Webui URL to be available"))
+            logger.info("Waiting for Webui URL to be available")
             return
 
         if not self._storage_is_attached():
@@ -137,11 +193,13 @@ class PCFOperatorCharm(CharmBase):
         if not self._container.can_connect():
             return False
 
-        for relation in [NRF_RELATION_NAME, TLS_RELATION_NAME]:
-            if not self._relation_created(relation):
-                return False
+        if self._missing_relations():
+            return False
 
         if not self._nrf_is_available():
+            return False
+
+        if not self._webui_url_is_available:
             return False
 
         if not self._storage_is_attached():
@@ -151,38 +209,6 @@ class PCFOperatorCharm(CharmBase):
             return False
 
         return True
-
-    def _configure_sdcore_pcf(self, event: EventBase) -> None:
-        """Add Pebble layer and manages Juju unit status.
-
-        Args:
-            event (EventBase): Juju event.
-        """
-        if not self.ready_to_configure():
-            logger.info("The preconditions for the configuration are not met yet.")
-            return
-
-        if not self._private_key_is_stored():
-            self._generate_private_key()
-
-        if not self._csr_is_stored():
-            self._request_new_certificate()
-
-        provider_certificate = self._get_current_provider_certificate()
-        if not provider_certificate:
-            return
-
-        if certificate_update_required := self._is_certificate_update_required(
-            provider_certificate
-        ):
-            self._store_certificate(certificate=provider_certificate)
-
-        desired_config_file = self._generate_pcf_config_file()
-        if config_update_required := self._is_config_update_required(desired_config_file):
-            self._push_config_file(content=desired_config_file)
-
-        should_restart = config_update_required or certificate_update_required
-        self._configure_pebble(restart=should_restart)
 
     def _is_certificate_update_required(self, provider_certificate) -> bool:
         """Check the provided certificate and existing certificate.
@@ -226,7 +252,28 @@ class PCFOperatorCharm(CharmBase):
             pcf_sbi_port=PCF_SBI_PORT,
             pod_ip=_get_pod_ip(),  # type: ignore[arg-type]
             scheme="https",
+            webui_uri=self._webui_requires.webui_url,
         )
+
+    def _missing_relations(self) -> List[str]:
+        """Return list of missing relations.
+
+        If all the relations are created, it returns an empty list.
+
+        Returns:
+            list: missing relation names.
+        """
+        missing_relations = []
+        for relation in [NRF_RELATION_NAME,
+                         TLS_RELATION_NAME,
+                         SDCORE_CONFIG_RELATION_NAME]:
+            if not self._relation_created(relation):
+                missing_relations.append(relation)
+        return missing_relations
+
+    @property
+    def _webui_url_is_available(self) -> bool:
+        return bool(self._webui_requires.webui_url)
 
     def _is_config_update_required(self, content: str) -> bool:
         """Decide whether config update is required by checking existence and config content.
@@ -387,6 +434,7 @@ class PCFOperatorCharm(CharmBase):
         pcf_sbi_port: int,
         pod_ip: str,
         scheme: str,
+        webui_uri: str,
     ) -> str:
         """Render the config file content.
 
@@ -395,6 +443,7 @@ class PCFOperatorCharm(CharmBase):
             pcf_sbi_port (int): PCF SBI port.
             pod_ip (str): Pod IPv4.
             scheme (str): SBI interface scheme ("http" or "https")
+            webui_uri (str) : URL of the Webui
 
         Returns:
             str: Config file content.
@@ -406,6 +455,7 @@ class PCFOperatorCharm(CharmBase):
             pcf_sbi_port=pcf_sbi_port,
             pod_ip=pod_ip,
             scheme=scheme,
+            webui_uri=webui_uri,
         )
 
     def _config_file_is_written(self) -> bool:

--- a/src/templates/pcfcfg.yaml.j2
+++ b/src/templates/pcfcfg.yaml.j2
@@ -1,6 +1,7 @@
 configuration:
   defaultBdtRefId: BdtPolicyId-
   nrfUri: {{ nrf_url }}
+  webuiUri: {{ webui_uri }}
   pcfName: PCF
   sbi:
     bindingIPv4: 0.0.0.0

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -22,3 +22,8 @@ output "logging_endpoint" {
   description = "Name of the endpoint used to integrate with the Logging provider."
   value       = "logging"
 }
+
+output "sdcore_config_endpoint" {
+  description = "Name of the endpoint used to integrate with the Webui."
+  value       = "sdcore_config"
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -66,7 +66,8 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     )
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_CHARM_NAME)
     await ops_test.model.integrate(
-        relation1=f"{APPLICATION_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+        relation1=f"{APPLICATION_NAME}:sdcore_config",
+        relation2=f"{WEBUI_CHARM_NAME}:sdcore-config",
     )
     await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:logging", relation2=GRAFANA_AGENT_CHARM_NAME
@@ -104,7 +105,8 @@ async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deplo
     assert ops_test.model
     await _deploy_webui(ops_test)
     await ops_test.model.integrate(
-        relation1=f"{APPLICATION_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+        relation1=f"{APPLICATION_NAME}:sdcore_config",
+        relation2=f"{WEBUI_CHARM_NAME}:sdcore-config",
     )
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -66,6 +66,9 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     )
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=TLS_CHARM_NAME)
     await ops_test.model.integrate(
+        relation1=f"{APPLICATION_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+    )
+    await ops_test.model.integrate(
         relation1=f"{APPLICATION_NAME}:logging", relation2=GRAFANA_AGENT_CHARM_NAME
     )
 
@@ -87,6 +90,22 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_nrf(ops_test)
     await ops_test.model.integrate(relation1=APPLICATION_NAME, relation2=NRF_CHARM_NAME)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
+
+@pytest.mark.abort_on_fail
+async def test_remove_webui_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(WEBUI_CHARM_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="blocked", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await _deploy_webui(ops_test)
+    await ops_test.model.integrate(
+        relation1=f"{APPLICATION_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+    )
     await ops_test.model.wait_for_idle(apps=[APPLICATION_NAME], status="active", timeout=1000)
 
 

--- a/tests/unit/expected_pcfcfg.yaml
+++ b/tests/unit/expected_pcfcfg.yaml
@@ -1,6 +1,7 @@
 configuration:
   defaultBdtRefId: BdtPolicyId-
   nrfUri: https://nrf:443
+  webuiUri: sdcore-webui:9876
   pcfName: PCF
   sbi:
     bindingIPv4: 0.0.0.0

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,0 +1,129 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from typing import Generator
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+import yaml
+from charm import (
+    NRF_RELATION_NAME,
+    PCFOperatorCharm,
+)
+from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
+    ProviderCertificate,
+)
+from ops import testing
+
+logger = logging.getLogger(__name__)
+
+CERTIFICATE = "whatever certificate content"
+CERTIFICATES_LIB = (
+    "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3"
+)
+CERTIFICATE_PATH = "support/TLS/pcf.pem"
+CSR = "whatever CSR content"
+CSR_PATH = "support/TLS/pcf.csr"
+EXPECTED_CONFIG_FILE_PATH = "tests/unit/expected_pcfcfg.yaml"
+POD_IP = b"1.1.1.1"
+PRIVATE_KEY = "whatever key content"
+PRIVATE_KEY_PATH = "support/TLS/pcf.key"
+VALID_NRF_URL = "https://nrf:443"
+WEBUI_URL = "sdcore-webui:9876"
+SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
+WEBUI_APPLICATION_NAME = "sdcore-webui-operator"
+
+
+class PCFUnitTestFixtures:
+    patcher_check_output = patch("charm.check_output")
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_certificates = patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
+    patcher_nrf_url = patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)  # noqa: E501
+    patcher_request_certificate = patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
+    patcher_restart_container = patch("ops.model.Container.restart")
+    patcher_webui_url = patch(
+        "charms.sdcore_webui_k8s.v0.sdcore_config.SdcoreConfigRequires.webui_url",
+        new_callable=PropertyMock
+    )
+
+    @pytest.fixture()
+    def setUp(self):
+        metadata = self._get_metadata()
+        self.container_name = list(metadata["containers"].keys())[0]
+        self.mock_check_output = PCFUnitTestFixtures.patcher_check_output.start()
+        self.mock_generate_csr = PCFUnitTestFixtures.patcher_generate_csr.start()
+        self.mock_generate_private_key = PCFUnitTestFixtures.patcher_generate_private_key.start()
+        self.mock_get_certificates = PCFUnitTestFixtures.patcher_get_certificates.start()
+        self.mock_nrf_url = PCFUnitTestFixtures.patcher_nrf_url.start()
+        self.mock_request_certificate = PCFUnitTestFixtures.patcher_request_certificate.start()
+        self.mock_restart_container = PCFUnitTestFixtures.patcher_restart_container.start()
+        self.mock_webui_url = PCFUnitTestFixtures.patcher_webui_url.start()
+
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+
+    @pytest.fixture()
+    def mock_default_values(self) -> None:
+        self.mock_nrf_url.return_value = VALID_NRF_URL
+        self.mock_webui_url.return_value = WEBUI_URL
+        self.mock_check_output.return_value = POD_IP
+        self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
+        self.mock_generate_csr.return_value = CSR.encode()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
+        self.harness = testing.Harness(PCFOperatorCharm)
+        self.harness.set_model_name(name="whatever")
+        self.harness.set_leader(is_leader=True)
+        self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
+
+    @pytest.fixture()
+    def add_storage(self) -> None:
+        self.harness.add_storage(storage_name="certs", attach=True)  # type:ignore
+        self.harness.add_storage(storage_name="config", attach=True)  # type:ignore
+
+    @pytest.fixture()
+    def get_default_certificate(self) -> None:
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR
+        self.mock_get_certificates.return_value = [provider_certificate]
+
+    @pytest.fixture()
+    def nrf_relation_id(self) -> Generator[int, None, None]:
+        relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
+        )
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")  # type:ignore
+        yield relation_id
+
+    @staticmethod
+    def _get_metadata() -> dict:
+        """Read `charmcraft.yaml` and return its content as a dictionary."""
+        with open("charmcraft.yaml", "r") as f:
+            data = yaml.safe_load(f)
+        return data
+
+    @pytest.fixture()
+    def sdcore_config_relation_id(self) -> Generator[int, None, None]:
+        sdcore_config_relation_id = self.harness.add_relation(  # type:ignore
+            relation_name=SDCORE_CONFIG_RELATION_NAME,
+            remote_app=WEBUI_APPLICATION_NAME,
+        )
+        self.harness.add_relation_unit(  # type:ignore
+            relation_id=sdcore_config_relation_id, remote_unit_name=f"{WEBUI_APPLICATION_NAME}/0"
+        )
+        self.harness.update_relation_data(  # type:ignore
+            relation_id=sdcore_config_relation_id,
+            app_or_unit=WEBUI_APPLICATION_NAME,
+            key_values={
+                "webui_url": WEBUI_URL,
+            },
+        )
+        yield sdcore_config_relation_id

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,21 +2,17 @@
 # See LICENSE file for licensing details.
 
 import logging
-from typing import Generator
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock
 
 import pytest
-import yaml
 from charm import (
     CONFIG_FILE_NAME,
-    NRF_RELATION_NAME,
     TLS_RELATION_NAME,
-    PCFOperatorCharm,
 )
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
     ProviderCertificate,
 )
-from ops import testing
+from fixtures import PCFUnitTestFixtures
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
@@ -33,77 +29,12 @@ POD_IP = b"1.1.1.1"
 PRIVATE_KEY = "whatever key content"
 PRIVATE_KEY_PATH = "support/TLS/pcf.key"
 VALID_NRF_URL = "https://nrf:443"
+WEBUI_URL = "sdcore-webui:9876"
+SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
+WEBUI_APPLICATION_NAME = "sdcore-webui-operator"
 
 
-class TestCharm:
-
-    patcher_check_output = patch("charm.check_output")
-    patcher_generate_csr = patch("charm.generate_csr")
-    patcher_generate_private_key = patch("charm.generate_private_key")
-    patcher_get_certificates = patch(f"{CERTIFICATES_LIB}.get_assigned_certificates")
-    patcher_nrf_url = patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)  # noqa: E501
-    patcher_request_certificate = patch(f"{CERTIFICATES_LIB}.request_certificate_creation")
-    patcher_restart_container = patch("ops.model.Container.restart")
-
-    @pytest.fixture()
-    def setUp(self):
-        metadata = self._get_metadata()
-        self.container_name = list(metadata["containers"].keys())[0]
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
-        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
-        self.mock_get_certificates = TestCharm.patcher_get_certificates.start()
-        self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
-        self.mock_request_certificate = TestCharm.patcher_request_certificate.start()
-        self.mock_restart_container = TestCharm.patcher_restart_container.start()
-
-    @staticmethod
-    def tearDown() -> None:
-        patch.stopall()
-
-    @pytest.fixture()
-    def mock_default_values(self) -> None:
-        self.mock_nrf_url.return_value = VALID_NRF_URL
-        self.mock_check_output.return_value = POD_IP
-        self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
-        self.mock_generate_csr.return_value = CSR.encode()
-
-    @pytest.fixture(autouse=True)
-    def harness(self, setUp, request):
-        self.harness = testing.Harness(PCFOperatorCharm)
-        self.harness.set_model_name(name="whatever")
-        self.harness.set_leader(is_leader=True)
-        self.harness.begin()
-        yield self.harness
-        self.harness.cleanup()
-        request.addfinalizer(self.tearDown)
-
-    @pytest.fixture()
-    def add_storage(self) -> None:
-        self.harness.add_storage(storage_name="certs", attach=True)  # type:ignore
-        self.harness.add_storage(storage_name="config", attach=True)  # type:ignore
-
-    @pytest.fixture()
-    def get_default_certificate(self) -> None:
-        provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = CERTIFICATE
-        provider_certificate.csr = CSR
-        self.mock_get_certificates.return_value = [provider_certificate]
-
-    @pytest.fixture()
-    def nrf_relation_id(self) -> Generator[int, None, None]:
-        relation_id = self.harness.add_relation(  # type:ignore
-            relation_name=NRF_RELATION_NAME, remote_app="nrf-operator"
-        )
-        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-operator/0")  # type:ignore
-        yield relation_id
-
-    @staticmethod
-    def _get_metadata() -> dict:
-        """Read `charmcraft.yaml` and return its content as a dictionary."""
-        with open("charmcraft.yaml", "r") as f:
-            data = yaml.safe_load(f)
-        return data
+class TestCharm(PCFUnitTestFixtures):
 
     @staticmethod
     def _read_file(path: str) -> str:
@@ -128,25 +59,38 @@ class TestCharm:
         assert self.harness.model.unit.status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_created_when_collect_status_then_status_is_blocked(  # noqa: E501
-        self,
+        self, sdcore_config_relation_id
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self._create_certificates_relation()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation(s)")
+
+    def test_given_container_can_connect_and_certificates_relation_is_not_created_when_collect_status_then_status_is_blocked(  # noqa: E501
+        self, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for certificates relation(s)"
+        )
 
-    def test_given_container_can_connect_and_certificates_relation_is_not_created_when_collect_status_then_status_is_blocked(  # noqa: E501
+    def test_given_container_can_connect_and_sdcore_config_relation_is_not_created_when_collect_status_then_status_is_blocked(  # noqa: E501
         self, nrf_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
-
+        self._create_certificates_relation()
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for sdcore_config relation(s)"
+        )
 
     def test_given_pcf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         root = self.harness.get_filesystem_root(self.container_name)
@@ -157,10 +101,28 @@ class TestCharm:
         self.harness.remove_relation(nrf_relation_id)
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for fiveg_nrf relation(s)"
+        )
+
+    def test_given_pcf_charm_in_active_state_when_sdcore_config_relation_breaks_then_status_is_blocked(  # noqa: E501
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        self._create_certificates_relation()
+        self.harness.container_pebble_ready(self.container_name)
+
+        self.harness.remove_relation(sdcore_config_relation_id)
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for sdcore_config relation(s)"
+        )
 
     def test_given_container_can_connect_and_fiveg_nrf_relation_is_not_available_when_collect_status_then_status_is_waiting(  # noqa: E501
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         self._create_certificates_relation()
         self.mock_nrf_url.return_value = None
@@ -170,6 +132,17 @@ class TestCharm:
 
         assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF endpoint to be available")  # noqa: E501
 
+    def test_given_container_can_connect_and_webui_url_is_not_available_when_collect_status_then_status_is_waiting(  # noqa: E501
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
+    ):
+        self._create_certificates_relation()
+        self.mock_webui_url.return_value = ""
+        self.harness.container_pebble_ready(self.container_name)
+
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for Webui URL to be available")  # noqa: E501
+
     @pytest.mark.parametrize(
         "storage_name",
         [
@@ -178,28 +151,31 @@ class TestCharm:
         ]
     )
     def test_given_container_storage_is_not_attached_when_collect_status_then_status_is_waiting(  # noqa: E501
-        self, storage_name, nrf_relation_id
+        self, storage_name, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.add_storage(storage_name=storage_name, attach=True)
         self._create_certificates_relation()
-
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == WaitingStatus("Waiting for the storage to be attached")  # noqa: E501
 
     def test_given_certificate_is_not_stored_when_collect_status_then_status_is_waiting(  # noqa: E501
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         self._create_certificates_relation()
-
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
     def test_given_config_file_is_written_when_collect_status_is_called_then_status_is_active(  # noqa: E501
-        self, add_storage, get_default_certificate, mock_default_values, nrf_relation_id
+        self,
+        add_storage,
+        get_default_certificate,
+        mock_default_values,
+        nrf_relation_id,
+        sdcore_config_relation_id,
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
@@ -212,7 +188,7 @@ class TestCharm:
         assert self.harness.model.unit.status == ActiveStatus()
 
     def test_given_ip_not_available_when_collect_status_then_status_is_waiting(
-        self, add_storage, nrf_relation_id
+        self, add_storage, nrf_relation_id, sdcore_config_relation_id
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
@@ -229,24 +205,30 @@ class TestCharm:
 
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Scaling is not implemented for this charm")  # noqa: E501
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Scaling is not implemented for this charm"
+        )
 
     def test_given_config_file_is_not_written_when_configure_sdcore_pcf_is_called_then_config_file_is_written_with_expected_content(  # noqa: E501
-        self, add_storage, get_default_certificate, mock_default_values, nrf_relation_id
+        self,
+        add_storage,
+        get_default_certificate,
+        mock_default_values,
+        nrf_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / CSR_PATH).write_text(CSR)
         self._create_certificates_relation()
-
         self.harness.charm._configure_sdcore_pcf(event=Mock())
 
         expected_config_file_content = self._read_file(EXPECTED_CONFIG_FILE_PATH).strip()
         assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text() == expected_config_file_content
 
     def test_given_config_file_is_written_and_is_not_changed_when_configure_sdcore_pcf_is_called_then_config_file_is_not_written(  # noqa: E501
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
@@ -261,28 +243,37 @@ class TestCharm:
 
         assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").stat().st_mtime == config_modification_time
 
-    def test_given_config_file_exists_and_is_changed_when_configure_pcf_then_config_file_is_updated(  # noqa: E501
-        self, add_storage, get_default_certificate, mock_default_values, nrf_relation_id
+    def test_given_config_file_exists_and_webui_url_is_changed_when_configure_pcf_then_config_file_is_updated(  # noqa: E501
+        self,
+        add_storage,
+        get_default_certificate,
+        mock_default_values,
+        nrf_relation_id,
+        sdcore_config_relation_id,
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CSR_PATH).write_text(CSR)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / f"etc/pcf/{CONFIG_FILE_NAME}").write_text("super different config file content")
         self._create_certificates_relation()
-
         self.harness.container_pebble_ready(self.container_name)
 
         expected_content = self._read_file(EXPECTED_CONFIG_FILE_PATH)
         assert (root / f"etc/pcf/{CONFIG_FILE_NAME}").read_text() == expected_content.strip()
 
+
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_pcf_is_called_then_expected_plan_is_applied(  # noqa: E501
-        self, add_storage, get_default_certificate, mock_default_values, nrf_relation_id
+        self,
+        add_storage,
+        get_default_certificate,
+        mock_default_values,
+        nrf_relation_id,
+        sdcore_config_relation_id,
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
         (root / CSR_PATH).write_text(CSR)
         self._create_certificates_relation()
-
         self.harness.container_pebble_ready(self.container_name)
 
         expected_plan = {
@@ -306,14 +297,13 @@ class TestCharm:
         assert expected_plan == updated_plan
 
     def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.mock_generate_private_key.return_value = PRIVATE_KEY.encode()
         self.mock_generate_csr.return_value = CSR.encode()
         self._create_certificates_relation()
-
         assert (root / PRIVATE_KEY_PATH).read_text() == PRIVATE_KEY
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
@@ -364,7 +354,7 @@ class TestCharm:
             (root / CSR_PATH).read_text()
 
     def test_given_private_key_exists_when_on_certificates_relation_joined_then_csr_is_generated(
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
@@ -372,11 +362,10 @@ class TestCharm:
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self._create_certificates_relation()
-
         assert (root / CSR_PATH).read_text() == CSR
 
     def test_given_private_key_exists_and_cert_not_yet_requested_when_on_certificates_relation_joined_then_cert_is_requested(  # noqa: E501
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, nrf_relation_id, sdcore_config_relation_id, mock_default_values
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
@@ -388,7 +377,7 @@ class TestCharm:
         self.mock_request_certificate.assert_called_with(certificate_signing_request=CSR.encode())
 
     def test_given_cert_already_stored_when_on_certificates_relation_joined_then_cert_is_not_requested(  # noqa: E501
-        self, add_storage, mock_default_values, nrf_relation_id
+        self, add_storage, mock_default_values, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=self.container_name, val=True)
         root = self.harness.get_filesystem_root(self.container_name)
@@ -401,7 +390,12 @@ class TestCharm:
         self.mock_request_certificate.assert_not_called()
 
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self, add_storage, get_default_certificate, mock_default_values, nrf_relation_id
+        self,
+        add_storage,
+        get_default_certificate,
+        mock_default_values,
+        nrf_relation_id,
+        sdcore_config_relation_id,
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
@@ -413,7 +407,7 @@ class TestCharm:
         assert (root / CERTIFICATE_PATH).read_text() == CERTIFICATE
 
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
-        self, add_storage, nrf_relation_id, mock_default_values
+        self, add_storage, nrf_relation_id, mock_default_values, sdcore_config_relation_id
     ):
         root = self.harness.get_filesystem_root(self.container_name)
         (root / PRIVATE_KEY_PATH).write_text(PRIVATE_KEY)
@@ -423,11 +417,46 @@ class TestCharm:
         provider_certificate.csr = "Relation CSR content (different from stored one)"
         self.mock_get_certificates.return_value = [provider_certificate]
         self._create_certificates_relation()
-
         self.harness.container_pebble_ready(self.container_name)
 
         with pytest.raises(FileNotFoundError):
             (root / CERTIFICATE_PATH).read_text()
+
+    @pytest.mark.parametrize(
+        "pod_ip,webui_url",
+        [
+            (b"1.2.3.4", WEBUI_URL),
+            (POD_IP, "mywebui:9876"),
+        ]
+    )
+    def test_config_pushed_but_config_changed_and_layer_already_applied_when_pebble_ready_then_pcf_service_is_restarted(  # noqa: E501
+        self,
+        pod_ip,
+        webui_url,
+        add_storage,
+        nrf_relation_id,
+        sdcore_config_relation_id,
+        mock_default_values,
+    ):
+        provider_certificate = Mock(ProviderCertificate)
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR
+        self.mock_get_certificates.return_value = [provider_certificate]
+
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / CSR_PATH).write_text(CSR)
+        (root / CERTIFICATE_PATH).write_text(CERTIFICATE)
+        (root / f"etc/pcf/{CONFIG_FILE_NAME}").write_text(
+            self._read_file(EXPECTED_CONFIG_FILE_PATH)
+        )
+
+        self._create_certificates_relation()
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self.mock_check_output.return_value = pod_ip
+        self.mock_webui_url.return_value = webui_url
+
+        self.harness.container_pebble_ready(self.container_name)
+        self.mock_restart_container.assert_called_once_with(self.container_name)
 
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
         self, add_storage


### PR DESCRIPTION
# Description

   - Implement requirer side of sdcore_config interface
   - Place _configure_sdcore_udm after charm constructor

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library