### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,4 +5,3 @@ pytest
 pytest-asyncio==0.21.2
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,117 +7,163 @@
 asttokens==2.4.1
     # via stack-data
 bcrypt==4.2.0
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 cachetools==5.5.0
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 durationpy==0.7
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 executing==2.1.0
     # via stack-data
 google-auth==2.35.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 hvac==2.3.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 kubernetes==31.0.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 macaroonbakery==1.3.4
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
-    # via typing-inspect
+    # via
+    #   -c requirements.txt
+    #   typing-inspect
 nodeenv==1.9.1
     # via pyright
 oauthlib==3.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.1
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -c requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
     # via
+    #   -c requirements.txt
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -128,30 +174,39 @@ pytest-asyncio==0.21.2
 pytest-operator==0.38.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.2
-    # via pyrfc3339
+    # via
+    #   -c requirements.txt
+    #   pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
 requests-oauthlib==2.0.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 rsa==4.9
-    # via google-auth
-ruff==0.6.8
+    # via
+    #   -c requirements.txt
+    #   google-auth
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -160,26 +215,34 @@ six==1.16.0
 stack-data==0.6.3
     # via ipython
 toposort==1.10
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 urllib3==2.2.3
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import PCFOperatorCharm
 
@@ -40,6 +40,6 @@ class PCFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=PCFOperatorCharm,
         )

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import PCFUnitTestFixtures
 
@@ -14,18 +14,18 @@ class TestCharmCertificatesRelationBroken(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -38,7 +38,7 @@ class TestCharmCertificatesRelationBroken(PCFUnitTestFixtures):
             with open(f"{tempdir}/pcf.key", "w") as f:
                 f.write("private key")
 
-            state_in = scenario.State(
+            state_in = testing.State(
                 relations=[certificates_relation],
                 containers=[container],
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer, ServiceStatus
 
@@ -14,7 +14,7 @@ from tests.unit.fixtures import PCFUnitTestFixtures
 
 class TestCharmCollectStatus(PCFUnitTestFixtures):
     def test_given_not_leader_when_collect_unit_status_then_status_is_blocked(self):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 
@@ -23,10 +23,10 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         assert state_out.unit_status == BlockedStatus("Scaling is not implemented for this charm")
 
     def test_given_container_not_ready_when_collect_unit_status_then_status_is_waiting(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -36,11 +36,11 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         assert state_out.unit_status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_relations_not_created_when_collect_unit_status_then_status_is_blocked(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -54,15 +54,15 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
     def test_given_nms_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation],
             leader=True,
@@ -77,23 +77,23 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
     def test_given_nrf_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nms_relation, nrf_relation],
             leader=True,
@@ -108,23 +108,23 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
     def test_given_webui_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nms_relation, nrf_relation],
             leader=True,
@@ -139,23 +139,23 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="pcf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, nrf_relation, nms_relation],
             leader=True,
@@ -171,32 +171,32 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -215,32 +215,32 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -262,32 +262,32 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -310,34 +310,34 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
                 layers={"pcf": Layer({"services": {"pcf": {}}})},
                 service_statuses={"pcf": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -360,21 +360,21 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[nrf_relation, certificates_relation, sdcore_config_relation],
@@ -388,24 +388,24 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
             expected_version = "1.2.3"
             with open(f"{tempdir}/workload-version", "w") as f:
                 f.write(expected_version)
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers=[container],
                 relations=[nrf_relation, certificates_relation, sdcore_config_relation],

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,7 +5,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import example_cert_and_key
@@ -17,32 +17,32 @@ class TestCharmConfigure(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -71,32 +71,32 @@ class TestCharmConfigure(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,
@@ -131,32 +131,32 @@ class TestCharmConfigure(PCFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nrf_relation = scenario.Relation(
+            nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/pcf/",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="pcf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, nrf_relation, nms_relation],
                 leader=True,


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library