### PR TITLE
chore: bump pcf rock to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ juju integrate sdcore-pcf-k8s:sdcore_config sdcore-nms-k8s:sdcore_config
 
 ## Image
 
-**pcf**: `ghcr.io/canonical/sdcore-pcf:1.5.2`
+**pcf**: `ghcr.io/canonical/sdcore-pcf:1.6.1`
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,9 +16,9 @@ containers:
     resource: pcf-image
     mounts:
       - storage: config
-        location: /etc/pcf/
+        location: /sdcore/config
       - storage: certs
-        location: /support/TLS
+        location: /sdcore/certs
 
 resources:
   pcf-image:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,7 +24,7 @@ resources:
   pcf-image:
     type: oci-image
     description: OCI image for 5G pcf
-    upstream-source: ghcr.io/canonical/sdcore-pcf:1.5.2
+    upstream-source: ghcr.io/canonical/sdcore-pcf:1.6.1
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -537,7 +537,7 @@ class PCFOperatorCharm(CharmBase):
                     self._service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/bin/pcf --pcfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
+                        "command": f"/bin/pcf --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._environment_variables,
                     },
                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,12 +41,12 @@ from ops.pebble import Layer
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_PORT = 8080
-BASE_CONFIG_PATH = "/etc/pcf"
+BASE_CONFIG_PATH = "/sdcore/config"
 CONFIG_FILE_NAME = "pcfcfg.yaml"
 PCF_SBI_PORT = 29507
 NRF_RELATION_NAME = "fiveg_nrf"
 TLS_RELATION_NAME = "certificates"
-CERTS_DIR_PATH = "/support/TLS"  # Certificate paths are hardcoded in PCF code
+CERTS_DIR_PATH = "/sdcore/certs"
 PRIVATE_KEY_NAME = "pcf.key"
 CERTIFICATE_NAME = "pcf.pem"
 CERTIFICATE_COMMON_NAME = "pcf.sdcore"
@@ -302,6 +302,8 @@ class PCFOperatorCharm(CharmBase):
             pod_ip=pod_ip,
             scheme="https",
             webui_uri=self._webui_requires.webui_url,
+            tls_pem=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
+            tls_key=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             log_level=log_level,
         )
 
@@ -465,6 +467,8 @@ class PCFOperatorCharm(CharmBase):
         pod_ip: str,
         scheme: str,
         webui_uri: str,
+        tls_pem: str,
+        tls_key: str,
         log_level: str,
     ) -> str:
         """Render the config file content.
@@ -475,6 +479,8 @@ class PCFOperatorCharm(CharmBase):
             pod_ip (str): Pod IPv4.
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui
+            tls_pem (str): Path to the TLS certificate.
+            tls_key (str): Path to the TLS private key.
             log_level (str): Log level for the PCF.
 
         Returns:
@@ -488,6 +494,8 @@ class PCFOperatorCharm(CharmBase):
             pod_ip=pod_ip,
             scheme=scheme,
             webui_uri=webui_uri,
+            tls_pem=tls_pem,
+            tls_key=tls_key,
             log_level=log_level,
         )
 

--- a/src/templates/pcfcfg.yaml.j2
+++ b/src/templates/pcfcfg.yaml.j2
@@ -8,6 +8,9 @@ configuration:
     port: {{ pcf_sbi_port }}
     registerIPv4: {{ pod_ip }}
     scheme: {{ scheme }}
+    tls:
+      pem: {{ tls_pem }}
+      key: {{ tls_key }}
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
   serviceList:

--- a/tests/unit/expected_pcfcfg.yaml
+++ b/tests/unit/expected_pcfcfg.yaml
@@ -8,6 +8,9 @@ configuration:
     port: 29507
     registerIPv4: 1.1.1.1
     scheme: https
+    tls:
+      pem: /sdcore/certs/pcf.pem
+      key: /sdcore/certs/pcf.key
   enableNrfCaching: true
   nrfCacheEvictionInterval: 900
   serviceList:

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -18,11 +18,11 @@ class TestCharmCertificatesRelationBroken(PCFUnitTestFixtures):
                 endpoint="certificates", interface="tls-certificates"
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=tempdir,
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=tempdir,
             )
             container = testing.Container(
@@ -30,8 +30,8 @@ class TestCharmCertificatesRelationBroken(PCFUnitTestFixtures):
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            os.mkdir(f"{tempdir}/support")
-            os.mkdir(f"{tempdir}/support/TLS")
+            os.mkdir(f"{tempdir}/sdcore")
+            os.mkdir(f"{tempdir}/sdcore/certs")
             with open(f"{tempdir}/pcf.pem", "w") as f:
                 f.write("certificate")
 

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -201,11 +201,11 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -245,11 +245,11 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -292,11 +292,11 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -340,11 +340,11 @@ class TestCharmCollectStatus(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS/",
+                location="/sdcore/certs/",
                 source=temp_dir,
             )
             container = testing.Container(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -183,7 +183,7 @@ class TestCharmConfigure(PCFUnitTestFixtures):
                             "pcf": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/pcf --pcfcfg /etc/pcf/pcfcfg.yaml",
+                                "command": "/bin/pcf --cfg /etc/pcf/pcfcfg.yaml",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -30,11 +30,11 @@ class TestCharmConfigure(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -84,11 +84,11 @@ class TestCharmConfigure(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -144,11 +144,11 @@ class TestCharmConfigure(PCFUnitTestFixtures):
                 interface="sdcore_config",
             )
             config_mount = testing.Mount(
-                location="/etc/pcf/",
+                location="/sdcore/config/",
                 source=temp_dir,
             )
             certs_mount = testing.Mount(
-                location="/support/TLS",
+                location="/sdcore/certs",
                 source=temp_dir,
             )
             container = testing.Container(
@@ -183,7 +183,7 @@ class TestCharmConfigure(PCFUnitTestFixtures):
                             "pcf": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/bin/pcf --cfg /etc/pcf/pcfcfg.yaml",
+                                "command": "/bin/pcf --cfg /sdcore/config/pcfcfg.yaml",
                                 "environment": {
                                     "POD_IP": "1.1.1.1",
                                     "MANAGED_BY_CONFIG_POD": "true",


### PR DESCRIPTION
# Description

Bump the charm's rock/workload version to v1.6.1. We also make the necessary change for our charm to keep on working:
- We replace the existing pcfcfg startup CLI command with the new cfg
- We use the new parameters for providing the SBI interface's TLS certificate and key

## Reference
- https://github.com/omec-project/pcf/releases/tag/v1.6.1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library