### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Aether SD-Core PCF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-pcf-k8s/badge.svg)](https://charmhub.io/sdcore-pcf-k8s)
 
-A Charmed Operator for Aether SD-Core's Policy Control Function (PCF) component for K8s. 
+> **:warning: Deprecation Notice!**
+>
+> This project is deprecated and will not receive further updates. Please refer to the upstream [Aether](https://aetherproject.org/) project to continue using Aether.
+
+A Charmed Operator for Aether SD-Core's Policy Control Function (PCF) component for K8s.
 
 ## Usage
 
 ```bash
 juju deploy mongodb-k8s --channel=6/stable --trust
 juju deploy sdcore-nrf-k8s --channel=1.6/edge
-juju deploy sdcore-pcf-k8s --channel=1.6/edge 
+juju deploy sdcore-pcf-k8s --channel=1.6/edge
 juju deploy sdcore-nms-k8s --channel=1.6/edge
 juju deploy self-signed-certificates --channel=stable
 


### PR DESCRIPTION
# Description

Add deprecation notice to let users know that we are deprecating Charmed Aether SD-Core.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library